### PR TITLE
Event show page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,8 +21,9 @@ gem 'sendgrid'
 gem 'uglifier', '>= 1.3.0'
 
 group :development, :test do
-  gem 'byebug', platform: :mri
   gem 'awesome_print'
+  gem 'byebug', platform: :mri
+  gem 'pry'
   gem 'rb-readline'
   gem 'rspec-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    coderay (1.1.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
     dalli (2.7.6)
@@ -126,6 +127,10 @@ GEM
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     pg (0.20.0)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     public_suffix (3.0.0)
     puma (3.8.2)
     rack (2.0.1)
@@ -197,6 +202,7 @@ GEM
     sendgrid (1.2.4)
       json
     sexp_processor (4.8.0)
+    slop (3.6.0)
     spring (2.0.1)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -251,6 +257,7 @@ DEPENDENCIES
   jquery-rails
   listen (~> 3.0.5)
   pg (~> 0.18)
+  pry
   puma (~> 3.0)
   rails (~> 5.0.0, >= 5.0.0.1)
   rails_12factor

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,8 @@
+class EventsController < ApplicationController
+  def show
+    raw_id = params[:id]
+    id = raw_id.split("-").last
+
+    @event = Event.by_id(id: id)
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -31,4 +31,14 @@ class Event
 
     JSON.parse(events_json_cache)
   end
+
+  def self.by_id(id:)
+    found_event = self.all.find { |event| event['id'] == id }
+
+    if !found_event
+      raise ActiveRecord::RecordNotFound
+    end
+
+    found_event
+  end
 end

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -1,0 +1,17 @@
+%header
+  .block-logo
+    %a{href: 'https://www.turing.io', target: "_blank"}
+      = image_tag("logo.png", size: "280x80", alt: "Turing Logo")
+
+  .container.block-banner.text-center
+    %h1 Try Coding
+    %h2 Learn the basics of programming
+%main
+  .block-upcoming-event
+    .container
+      .gear-top
+      = render partial: 'partials/event', locals: {event: @event, label: 'EVENT'}
+  .block-try-turing-explained
+    .container
+      %h3.text-center
+        <em>Try Coding</em> is an initiative from the <a href='http://turing.io' target='_blank'>Turing School</a> that will expose you to the basics of programming. We'll introduce you to programming fundamentals for building web applications, and to the basics of HTML, CSS and JavaScript.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
   root 'application#index'
   post '/contact', to: 'application#contact'
+
+  resources :events, only: [:show]
 end

--- a/spec/features/guest_views_homepage_spec.rb
+++ b/spec/features/guest_views_homepage_spec.rb
@@ -22,4 +22,29 @@ describe 'user visiting homepage 'do
       expect(page).to have_content('Learn the basics of programming')
     end
   end
+
+  scenario 'visiting a particular event' do
+    url = 'https://www.eventbrite.com/e/try-coding-front-back-end-2-days-tickets-40888038223'
+
+    expect(Event).to receive(:all).and_return(
+      [{
+        'attendees' => [],
+        'id' => '40888038223',
+        'start' => {
+          'local' => DateTime.current.to_s
+        },
+        'name' => {
+          'text' => 'event name try coding'
+        },
+        'description' => {
+          'text' => 'event description'
+        },
+        'url' => url
+      }]
+    )
+
+    visit event_path(url.split("/").last)
+
+    expect(page).to have_content("event name try coding")
+  end
 end


### PR DESCRIPTION
We want to be able to market to specific events in online ads.

This changeset introduces a new events show page at /events/:id where
:id is the last url part of the eventbrite url. For example, if the
event name is Turing Try Coding, we'll get an eventbrite url ending in
something like 'turing-try-coding-124445'. We use that string as our :id
param and then pluck off the integers at the end of it (after the last
dash) to look up the event in our internal cache of the event data.

https://trello.com/c/eCA7eRyA/124-create-event-specific-page-in-tryturing

![screen shot 2018-02-15 at 12 32 34 pm](https://user-images.githubusercontent.com/2181356/36276840-55b81526-124c-11e8-8fe5-65db66ccd44e.png)
