### PR TITLE
Serialize Google structured event data

### DIFF
--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -1,7 +1,7 @@
 module EventHelper
   def venue_google_maps_url(venue)
     return false if venue.nil?
-    'https://maps.google.com/?q=' + URI::encode(venue['name'] + ' ' + venue['address']['localized_address_display'])
+    'https://maps.google.com/?q=' + URI::encode((venue['name'] || '') + ' ' + venue['address']['localized_address_display'])
   end
 
   def event_description(event)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -9,9 +9,10 @@ class Event
     events_json_cache = Rails.cache.fetch('events', expires_in: 1.hour) do
       # Get all Turing events
       events = Eventbrite::User.owned_events({
-        user_id: 'me',
+        expand: 'venue',
         order_by: 'start_asc',
-        status: 'live'
+        status: 'live',
+        user_id: 'me'
       }).events
 
       events = events.select do |event|

--- a/app/serializers/structured_event_serializer.rb
+++ b/app/serializers/structured_event_serializer.rb
@@ -1,0 +1,36 @@
+class StructuredEventSerializer
+  attr_reader :event
+
+  def initialize(event)
+    @event = event
+  end
+
+  def to_json
+    {
+      "@context": "http://schema.org",
+      "@type": "Event",
+      "name": "#{event['name']['text']}",
+      "startDate": "#{event['start']['local']}",
+      "location": {
+        "@type": "Place",
+        "name": "#{event['venue']['name']}",
+        "address": {
+          "@type": "PostalAddress",
+          "streetAddress": "#{event['venue']['address']['address_1']}",
+          "addressLocality": "#{event['venue']['address']['city']}",
+          "postalCode": "#{event['venue']['address']['postal_code']}",
+          "addressRegion": "#{event['venue']['address']['region']}",
+          "addressCountry": "#{event['venue']['address']['country']}"
+        }
+      },
+      "image": [
+        "#{event['logo']['original']['url']}"
+       ],
+      "description": "#{event['description']['text'].first(200)}",
+      "performer": {
+        "@type": "PerformingGroup",
+        "name": "Turing School"
+      }
+    }.to_json
+  end
+end

--- a/app/views/partials/_event.html.haml
+++ b/app/views/partials/_event.html.haml
@@ -1,6 +1,10 @@
 - attendees_to_show = 7
 - remaining_attendees = event['attendees'].size - attendees_to_show
 
+%script{type: "application/ld+json"}
+  :plain
+    #{StructuredEventSerializer.new(event).to_json}
+
 .event
   .event-box
     .row

--- a/spec/features/guest_views_homepage_spec.rb
+++ b/spec/features/guest_views_homepage_spec.rb
@@ -13,6 +13,22 @@ describe 'user visiting homepage 'do
         },
         'description' => {
           'text' => 'event description'
+        },
+        'venue' => {
+          'address' => {
+            'address_1' => '123 Street Road',
+            'city' => 'Denver',
+            'postal_code' => '80210',
+            'region' => 'CO',
+            'country' => 'US',
+            'localized_address_display' => 'pretty address display'
+          },
+          'name' => 'venue name'
+        },
+        'logo' => {
+          'original' => {
+            'url' => 'http://linktoimage.turing.com'
+          }
         }
       }]
     )
@@ -39,7 +55,23 @@ describe 'user visiting homepage 'do
         'description' => {
           'text' => 'event description'
         },
-        'url' => url
+        'url' => url,
+        'venue' => {
+          'address' => {
+            'address_1' => '123 Street Road',
+            'city' => 'Denver',
+            'postal_code' => '80210',
+            'region' => 'CO',
+            'country' => 'US',
+            'localized_address_display' => 'pretty address display'
+          },
+          'name' => 'venue name'
+        },
+        'logo' => {
+          'original' => {
+            'url' => 'http://linktoimage.turing.com'
+          }
+        }
       }]
     )
 

--- a/spec/serializers/structured_event_serializer_spec.rb
+++ b/spec/serializers/structured_event_serializer_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe StructuredEventSerializer do
+  describe '#to_json' do
+    it 'renders out a string' do
+      event = {
+        description: {
+          text: 'desc'
+        },
+        name: {
+          text: 'event name'
+        },
+        start: {
+          local: 'start'
+        },
+        venue: {
+          name: 'venue name',
+          address: {}
+        },
+        logo: {
+          original: {
+            url: 'img url'
+          }
+        },
+      }.with_indifferent_access
+
+      serializer = StructuredEventSerializer.new(event)
+
+      result = serializer.to_json
+
+      expect(JSON.parse(result)["name"]).to eq('event name')
+    end
+  end
+end


### PR DESCRIPTION
We want Google to crawl our events and display them nicely in search
results.

This changeset adds structured event data on the index page and on each
event page per
https://developers.google.com/search/docs/data-types/event

https://trello.com/c/LzNxInCp/148-make-trycoding-events-show-up-semantically-in-google-searches