### PR TITLE
Add YouTube video to homepage

### DIFF
--- a/app/assets/stylesheets/partials/_block-try-turing-explained.scss
+++ b/app/assets/stylesheets/partials/_block-try-turing-explained.scss
@@ -4,4 +4,25 @@
     hr {
         margin: 60px auto;
     }
+
+    .video-container {
+        height: 0;
+        margin: 0 auto;
+        max-width: 100%;
+        overflow: hidden;
+        padding-bottom: 315px;
+        padding-top: 30px;
+        position: relative;
+        text-align: center;
+        width: 560px;
+    }
+
+    .video-container iframe, .video-container object, .video-container embed {
+        display: block;
+        height: 100%;
+        max-height: 315px;
+        max-width: 560px;
+        position: absolute;
+        width: 100%;
+    }
 }

--- a/app/views/application/index.html.haml
+++ b/app/views/application/index.html.haml
@@ -15,6 +15,10 @@
     .container
       %h3.text-center
         <em>Try Coding</em> is an initiative from the <a href='http://turing.io' target='_blank'>Turing School</a> that will expose you to the basics of programming. We'll introduce you to programming fundamentals for building web applications, and to the basics of HTML, CSS and JavaScript.
+
+      %div.video-container
+        <iframe width="560" height="315" src="https://www.youtube.com/embed/X90j4wT7xes" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+
       %hr
       %p.text-center
         %a{href:"#all-events", class: 'btn btn-ghost btn-lg btn-primary'}


### PR DESCRIPTION
Why:

* we want to explain in more ways what Try Coding is before folks click
  out to Eventbrite

This change addresses the need by:

* embed our Try Coding youtube video onto the homepage

![screen shot 2018-04-05 at 8 31 33 am](https://user-images.githubusercontent.com/2181356/38372539-4d4471a6-38ac-11e8-9354-70d98b7b3257.png)
