### PR TITLE
Remove weekend from html title

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,14 +4,12 @@
     %meta{content: "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}
     %meta{content: "width=device-width,initial-scale=1.0", name: "viewport"}
     %meta{content: "http://trycoding.turing.io", property: "og:url"}
-    %meta{content: "Try Coding Weekend", property: "og:title"}
-    %meta{content: "Try Coding Weekend is a two-day program from the Turing School that will expose you to the basics of programming. We'll introduce you to Ruby, a popular programming language for building web applications, and to the basics of HTML, CSS and JavaScript.", property: "og:description"}
+    %meta{content: "Try Coding", property: "og:title"}
+    %meta{content: "Try Coding is a program from the Turing School that will expose you to the basics of programming. We'll introduce you to Ruby, a popular programming language for building web applications, and to the basics of HTML, CSS and JavaScript.", property: "og:description"}
     %meta{content: "Try Coding Weekend", property: "og:site_name"}
     %meta{content: image_url('students-working-1.jpg'), property: "og:image"}
-    -# %meta{content: "[FILLE ME IN]", property: "og:image:width"}
-    -# %meta{content: "[FILLE ME IN]", property: "og:image:height"}
 
-    %title Try Coding Weekend | Turing School of Software & Design
+    %title Try Coding | Turing School of Software & Design
     = stylesheet_link_tag    'application', media: 'all'
     = favicon_link_tag 'turing.ico'
     = javascript_include_tag 'application'


### PR DESCRIPTION
It's not always a weekend and it's not always two days. This change
makes it more generic / applicable