### PR TITLE
Enable bot honeypot in contact form

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  invisible_captcha only: [:contact], honeypot: :topic
 
   require 'eventbrite'
 
@@ -8,7 +9,12 @@ class ApplicationController < ActionController::Base
   end
 
   def contact
-    ContactMailer.form_request(params[:name], params[:email], params[:reason], params[:message]).deliver_now
+    ContactMailer.form_request(
+      params[:name],
+      params[:email],
+      params[:reason],
+      params[:message]
+    ).deliver_now
     head :ok
   end
 end

--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -1,12 +1,16 @@
 class ContactMailer < ApplicationMailer
 	include SendGrid
 
-	def form_request(name, email, reason, message)
-		@name    = name
+  def form_request(name, email, reason, message)
+    @name    = name
     @email   = email
-		@reason  = reason
-		@message = message
+    @reason  = reason
+    @message = message
 
-		mail(from: "\"#{@name}\" <#{@email}>", to: 'contact@turing.io', subject: 'Try Turing Contact Request')
-	end
+    mail(
+      from: "\"#{@name}\" <#{@email}>",
+      to: 'contact@turing.io',
+      subject: 'Try Turing Contact Request'
+    )
+  end
 end

--- a/app/views/partials/_contact.html.haml
+++ b/app/views/partials/_contact.html.haml
@@ -14,7 +14,7 @@
           .col-sm-4
             .form-group.has-feedback
               = label_tag 'name', 'Your Email *'
-              = text_field_tag "email", nil, placeholder: 'john@example.com', required: true, class: 'form-control', minlength: 2
+              = email_field_tag "email", nil, placeholder: 'john@example.com', required: true, class: 'form-control', minlength: 2
               %span{class: "fa form-control-feedback", 'aria-hidden': true}
           .col-sm-4
             .form-group.has-feedback


### PR DESCRIPTION
Why:

* we got odd looking errors in
  https://app.honeybadger.io/projects/54963/faults/37954423#notice-summary
  where we got garbage email addresses from the contact form.

This change addresses the need by:

* it was a bot and our captcha honeypot was in the form but not checking
  server side. Now it is checked server side and we also use the email
  type for the email input field to give human users a tad more
  feedback.