### PR TITLE
Update invisible_captcha gem to support Rails 5.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
       domain_name (~> 0.5)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
-    invisible_captcha (0.9.2)
+    invisible_captcha (0.10.0)
       rails (>= 3.2.0)
     jbuilder (2.6.3)
       activesupport (>= 3.0.0, < 5.2)
@@ -130,7 +130,7 @@ GEM
     minitest (5.11.3)
     multi_json (1.12.1)
     netrc (0.11.0)
-    nio4r (2.3.0)
+    nio4r (2.3.1)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     pg (0.20.0)
@@ -283,4 +283,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   1.15.4
+   1.16.2


### PR DESCRIPTION
Why:

* we need this upgrade to support Rails 5.1 and remove the erros we're
  seeing in
  https://app.honeybadger.io/projects/54963/faults/37967548#notice-summary
  around `redirect_to` usage

This change addresses the need by:

* bumping the gem