### PR TITLE
Redirect all requests to new turing.io/trycoding

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,5 +11,9 @@ module TryTuring
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    # Middleware for permanent redirect to new turing.io/trycoding
+    require_relative '../lib/redirector'
+    config.middleware.use Redirector
   end
 end

--- a/lib/redirector.rb
+++ b/lib/redirector.rb
@@ -1,0 +1,18 @@
+class Redirector
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    request = Rack::Request.new(env)
+    if request.get?
+      # making permanent redirect to new turing.io try coding site
+      [301, {"Location" => "https://turing.io/trycoding"}, self]
+    else
+      @app.call(env)
+    end
+  end
+
+  def each(&block)
+  end
+end

--- a/spec/features/guest_views_homepage_spec.rb
+++ b/spec/features/guest_views_homepage_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe 'user visiting homepage 'do
   scenario 'shows the events' do
+    skip
     expect(Event).to receive(:all).and_return(
       [{
         'attendees' => [],
@@ -40,6 +41,7 @@ describe 'user visiting homepage 'do
   end
 
   scenario 'visiting a particular event' do
+    skip
     url = 'https://www.eventbrite.com/e/try-coding-front-back-end-2-days-tickets-40888038223'
 
     expect(Event).to receive(:all).and_return(


### PR DESCRIPTION
We are no longer using this application for information about Try Coding. 

- all get requests are now permanently redirected to  `https://turing.io/trycoding`
- skip tests

Reason:
Since we can't use CNAMEs (trycoding.turing.io) to point to a specific path i.e. `/trycoding` for now it is easier to just redirect all request rather than set up some weird things on AWS. **Sorry**

Card: https://trello.com/c/WcqY0oCU/552-change-trycodingturingio-to-point-to-turingio-try-coding